### PR TITLE
Playready v3.3 support changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
    set(STAGING_DIR "${CMAKE_FIND_ROOT_PATH}")
 endif()
 
-find_package(PlayReady REQUIRED)
+find_package(PlayReady)
 
 file(GLOB DRM_PLUGIN_INCLUDES *.h)
 

--- a/MediaSession.h
+++ b/MediaSession.h
@@ -20,7 +20,17 @@
 #include "cdmi.h"
 
 #include <drmbuild_oem.h>
+#ifdef PR_3_3
+#include <drmbytemanip.h>
+#if defined( min )
+    #undef min(a,b)
+#endif /* defined( min ) */
+#if defined( max )
+    #undef max(a,b)
+#endif /* defined( max ) */
+#else /* PR_3_3 */
 #include <drmcommon.h>
+#endif /* PR_3_3 */
 #include <drmmanager.h>
 #include <drmmathsafe.h>
 #include <drmtypes.h>
@@ -98,7 +108,13 @@ public:
 
 
 private:
-    static DRM_RESULT DRM_CALL _PolicyCallback(const DRM_VOID *, DRM_POLICY_CALLBACK_TYPE f_dwCallbackType, const DRM_VOID *);
+
+
+    static DRM_RESULT DRM_CALL _PolicyCallback(const DRM_VOID *, DRM_POLICY_CALLBACK_TYPE f_dwCallbackType, 
+#ifdef PR_3_3
+        const DRM_KID *, const DRM_LID *,
+#endif
+        const DRM_VOID *);
 
     DRM_APP_CONTEXT *m_poAppContext;
     DRM_DECRYPT_CONTEXT m_oDecryptContext;
@@ -108,7 +124,11 @@ private:
 
     DRM_BYTE *m_pbRevocationBuffer;
     KeyState m_eKeyState;
+#ifdef PR_3_3
+    DRM_CHAR m_rgchSessionID[CCH_BASE64_EQUIV(sizeof(DRM_ID)) + 1];
+#else
     DRM_CHAR m_rgchSessionID[CCH_BASE64_EQUIV(SIZEOF(DRM_ID)) + 1];
+#endif
     DRM_BOOL m_fCommit;
       
     DRM_BYTE *m_pbChallenge;

--- a/cmake/FindPlayReady.cmake
+++ b/cmake/FindPlayReady.cmake
@@ -18,6 +18,10 @@ if(PC_PLAYREADY_FOUND)
         endif()
     endif()
 
+    if (PC_PLAYREADY_VERSION AND "${PC_PLAYREADY_VERSION}" EQUAL "3.3")
+        add_definitions(-DPR_3_3)
+    endif()
+
     if(PC_PLAYREADY_FOUND)
 
         # CPFLAGS += -DDRM_BUILD_PROFILE=DRM_BUILD_PROFILE_OEM  

--- a/cmake/FindPlayReady.cmake
+++ b/cmake/FindPlayReady.cmake
@@ -7,7 +7,7 @@
 #
 
 find_package(PkgConfig)
-pkg_check_modules(PC_PLAYREADY playready)
+pkg_check_modules(PC_PLAYREADY REQUIRED playready)
 
 if(PC_PLAYREADY_FOUND)
     if(PLAYREADY_FIND_VERSION AND PC_PLAYREADY_VERSION)


### PR DESCRIPTION
1. Replacing v3.3 deprecated Drm_Reader_InitDecrypt() and Drm_Reader_Decrypt() with
Drm_Reader_InitDecrypt and Drm_Reader_DecryptOpaque()
2. Drm_LicenseAcq_ProcessResponse() number of arguments change
3. Drm_LicenseAcq_GenerateChallenge() arguments list should end with NULL
4. invoke Drm_Reader_Bind() before Drm_LicenseAcq_GenerateChallenge
5. Make Playready dependency mandatory properly