### PR TITLE
Fix missing return statement in MediaKeySession::Close()

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -452,7 +452,9 @@ CDMi_RESULT MediaKeySession::Remove(void) {
   return CDMi_S_FALSE;
 }
 
-CDMi_RESULT MediaKeySession::Close(void) {}
+CDMi_RESULT MediaKeySession::Close(void) {
+  return CDMi_S_FALSE;
+}
 
 CDMi_RESULT MediaKeySession::Decrypt(
     const uint8_t *f_pbSessionKey,


### PR DESCRIPTION
Fixes:
  OCDM-Playready/MediaSession.cpp: In member function ‘virtual CDMi::CDMi_RESULT CDMi::MediaKeySession::Close()’:
  OCDM-Playready/MediaSession.cpp:455:43: warning: no return statement in function returning non-void [-Wreturn-type]
    CDMi_RESULT MediaKeySession::Close(void) {}
                                           ^