### PR TITLE
playready 3.3 compatibility and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(MODULE_NAME Playready)
 
+option(NETFLIX "Enable Netflix DRM" ON)
+
 find_package(PlayReady REQUIRED)
 
 add_library(${MODULE_NAME} SHARED
@@ -18,7 +20,11 @@ set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)
 
+if (NETFLIX)
 include("${PLAYREADY_INCLUDE}/playready.cmake")
+
+add_compile_definitions(NETFLIX)
+endif()
 
 target_include_directories(${MODULE_NAME}
     PRIVATE
@@ -26,10 +32,14 @@ target_include_directories(${MODULE_NAME}
     "${CMAKE_SYSROOT}/usr/include/${NAMESPACE}"
     ${PLAYREADY_INCLUDE_DIRS})
 
-
+if (NETFLIX)
 target_link_libraries(${MODULE_NAME}
     PRIVATE
         PlayReady::PlayReady)
+else()
+target_link_libraries(${MODULE_NAME}
+    ${PLAYREADY_LIBRARIES})
+endif()
 
 # Library installation section
 set_target_properties(${MODULE_NAME} PROPERTIES SUFFIX ".drm")

--- a/MediaSession.h
+++ b/MediaSession.h
@@ -22,7 +22,6 @@
 #include <drmmathsafe.h>
 #include <drmtypes.h>
 #ifndef SIZEOF
-#define PR_3_3
 #define SIZEOF sizeof
 #include <drmcrt.h>
 #undef min
@@ -33,6 +32,9 @@
 #endif
 #include <drmerr.h>
 #include <drmerror.h>
+#if defined(PR_3_3) && !defined(NETFLIX)
+#include <drmversionconstants.h>
+#endif
 
 #undef __in
 #undef __out

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -40,8 +40,13 @@ Core::CriticalSection drmAppContextMutex_;
 static DRM_WCHAR* createDrmWchar(std::string const& s) {
     DRM_WCHAR* w = new DRM_WCHAR[s.length() + 1];
     for (size_t i = 0; i < s.length(); ++i)
+#ifdef PR_3_3
+        w[i] = DRM_ONE_WCHAR(s[i], '\0');
+    w[s.length()] = DRM_ONE_WCHAR('\0', '\0');
+#else
         w[i] = ONE_WCHAR(s[i], '\0');
     w[s.length()] = ONE_WCHAR('\0', '\0');
+#endif
     return w;
 }
 
@@ -123,6 +128,7 @@ public:
        SafeCriticalSection lock(drmAppContextMutex_);
 
        DRM_UINT64 utctime64;
+#ifdef NETFLIX
        DRM_RESULT err = Drm_Clock_GetSystemTime(m_poAppContext.get(), &utctime64);
        if (err != DRM_SUCCESS) {
            fprintf(stderr, "Error: Drm_Clock_GetSystemTime returned 0x%lX\n", (long)err);
@@ -131,6 +137,7 @@ public:
        } else {
            return static_cast<uint64_t>(utctime64);
        }
+#endif
 
        return 0;
 
@@ -165,11 +172,13 @@ public:
         ASSERT(m_poAppContext.get() != nullptr);
 
         uint32_t ldlLimit = 0;
+#ifdef NETFLIX
         DRM_RESULT err = Drm_LicenseAcq_GetLdlSessionsLimit_Netflix(m_poAppContext.get(), &ldlLimit);
         if (err != DRM_SUCCESS) {
             fprintf(stderr, "Error: Drm_LicenseAcq_GetLdlSessionsLimit_Netflix returned 0x%lX\n", (long)err);
             return 0;
         }
+#endif
 
         return ldlLimit;
     }
@@ -177,13 +186,19 @@ public:
     bool IsSecureStopEnabled() override
     {
         SafeCriticalSection lock(drmAppContextMutex_);
+#ifdef NETFLIX
         return static_cast<bool>(Drm_SupportSecureStop());
+#else
+        return false;
+#endif
     }
 
     CDMi_RESULT EnableSecureStop(bool enable) override
     {
         SafeCriticalSection lock(drmAppContextMutex_);
+#ifdef NETFLIX
         Drm_TurnSecureStop(static_cast<int>(enable));
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -192,15 +207,20 @@ public:
     {
         SafeCriticalSection lock(drmAppContextMutex_);
         // if secure stop is not supported, return
-        DRM_BOOL supported = Drm_SupportSecureStop();
+        DRM_BOOL supported = FALSE;
+#ifdef NETFLIX
+        supported  = Drm_SupportSecureStop();
+#endif
         if (supported == FALSE)
             return 0;
 
         DRM_WORD numDeleted = 0;
+#ifdef NETFLIX
         DRM_RESULT err = Drm_ResetSecureStops(m_poAppContext.get(), &numDeleted);
         if (err != DRM_SUCCESS) {
             fprintf(stderr, "Drm_ResetSecureStops returned 0x%lx\n", (long)err);
         }
+#endif
         return numDeleted;
     }
 
@@ -209,10 +229,14 @@ public:
         SafeCriticalSection lock(drmAppContextMutex_);
 
         // if secure stop is not supported, return NotAllowed
-        DRM_BOOL supported = Drm_SupportSecureStop();
+        DRM_BOOL supported = FALSE;
+#ifdef NETFLIX
+        supported = Drm_SupportSecureStop();
+#endif
         if (supported == FALSE)
             return CDMi_SUCCESS;
 
+#ifdef NETFLIX
         DRM_BYTE sessionIds[TEE_MAX_NUM_SECURE_STOPS][TEE_SESSION_ID_LEN];
         DRM_RESULT err = Drm_GetSecureStopIds(m_poAppContext.get(), sessionIds, &count);
         if (err != DRM_SUCCESS) {
@@ -223,6 +247,7 @@ public:
         for (int i = 0; i < count; ++i) {
             memcpy(&ids[i * TEE_SESSION_ID_LEN], sessionIds[i], TEE_SESSION_ID_LEN);
         }
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -236,7 +261,10 @@ public:
         SafeCriticalSection lock(drmAppContextMutex_);
 
         // if secure stop is not supported, return
-        DRM_BOOL supported = Drm_SupportSecureStop();
+        DRM_BOOL supported = FALSE;
+#ifdef NETFLIX
+        supported = Drm_SupportSecureStop();
+#endif
         if (supported == FALSE)
             return CDMi_SUCCESS;
 
@@ -245,6 +273,7 @@ public:
             return CDMi_S_FALSE;
         }
 
+#ifdef NETFLIX
         // convert our vector to the uuid, sessionID is only supposed to be 16 bytes long
         uint8_t uuid[TEE_SESSION_ID_LEN];
         memcpy(&uuid[0], &sessionID[0], TEE_SESSION_ID_LEN);
@@ -256,6 +285,7 @@ public:
             fprintf(stderr, "Drm_GetSecureStop(0) returned 0x%lx\n", (long)err);
             return CDMi_S_FALSE;
         }
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -269,7 +299,10 @@ public:
         SafeCriticalSection lock(drmAppContextMutex_);
 
         // if secure stop is not supported, return
-        DRM_BOOL supported = Drm_SupportSecureStop();
+        DRM_BOOL supported = FALSE;
+#ifdef NETFLIX
+        supported = Drm_SupportSecureStop();
+#endif
         if (supported == FALSE)
             return CDMi_SUCCESS;
 
@@ -278,7 +311,7 @@ public:
             return CDMi_INVALID_ARG;
         }
 
-
+#ifdef NETFLIX
         // convert our vector to the uuid, sessionID is only supposed to be 16 bytes long
         uint8_t uuid[TEE_SESSION_ID_LEN];
         memcpy(&uuid[0], &sessionID[0], TEE_SESSION_ID_LEN);
@@ -289,6 +322,7 @@ public:
         {
             fprintf(stderr, "Drm_CommitSecureStop returned 0x%lx\n", (long)err);
         }
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -297,12 +331,14 @@ public:
     {
         SafeCriticalSection lock(drmAppContextMutex_);
 
+#ifdef NETFLIX
         DRM_RESULT err = Drm_DeleteKeyStore();
         if (err != DRM_SUCCESS)
         {
             fprintf(stderr, "Error: Drm_DeleteKeyStore returned 0x%lX\n", (long)err);
             return CDMi_S_FALSE;
         }
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -311,12 +347,14 @@ public:
     {
         SafeCriticalSection lock(drmAppContextMutex_);
 
+#ifdef NETFLIX
         DRM_RESULT err = Drm_DeleteSecureStore(&drmStore_);
         if (err != DRM_SUCCESS)
         {
             fprintf(stderr, "Error: Drm_DeleteSecureStore returned 0x%lX\n", (long)err);
             return CDMi_S_FALSE;
         }
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -333,12 +371,14 @@ public:
             return CDMi_S_FALSE;
         }
 
+#ifdef NETFLIX
         DRM_RESULT err = Drm_GetKeyStoreHash(keyStoreHash);
         if (err != DRM_SUCCESS)
         {
             fprintf(stderr, "Error: Drm_GetSecureStoreHash returned 0x%lX\n", (long)err);
             return CDMi_S_FALSE;
         }
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -355,12 +395,14 @@ public:
             return CDMi_S_FALSE;
         }
 
+#ifdef NETFLIX
         DRM_RESULT err = Drm_GetSecureStoreHash(&drmStore_, secureStoreHash);
         if (err != DRM_SUCCESS)
         {
             fprintf(stderr, "Error: Drm_GetSecureStoreHash returned 0x%lX\n", (long)err);
             return CDMi_S_FALSE;
         }
+#endif
 
         return CDMi_SUCCESS;
     }
@@ -412,7 +454,11 @@ public:
         DRM_RESULT err;
 
         // DRM Platform Initialization
+#ifdef PR_3_3
+        err = Drm_Platform_Initialize(nullptr);
+#else
         err = Drm_Platform_Initialize();
+#endif
         if(DRM_FAILED(err))
         {
             if (m_poAppContext.get() != nullptr) {


### PR DESCRIPTION
  - setting null to clear content ptr after Decrypt_Opaque() is removed and added before the call
  - redefinition of PR_3_3 removed
  - DecryptContext pointer in DRM APIs are mentioned based on version
  - introduced NETFLIX variable to conditionally called Netflix DRM APIs
  - CMakelists.txt - NETFLIX option enabled (can be disabled from a bbappend)
  - CMakelists.txt - linked playready static libraries through variable

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>