### PR TITLE
Modified MediaKeySession destructor to call Drm_Uninitialize.

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -307,6 +307,8 @@ MediaKeySession::~MediaKeySession(void) {
   if (DRM_REVOCATION_IsRevocationSupported())
     SAFE_OEM_FREE(m_pbRevocationBuffer);
 
+  Drm_Uninitialize( m_poAppContext );
+
   SAFE_OEM_FREE(m_pbOpaqueBuffer);
   printf("Destructing PlayReady Session [%p]\n", this);
 }


### PR DESCRIPTION
After few playback of YouTube content, I was seeing following error:
playready error: There are no more key registers available in the OEM HAL implementation.