### PR TITLE
Removed checks for IV size and m_eKeyState state in MediaKeySession::Decrypt()

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -543,8 +543,7 @@ CDMi_RESULT MediaKeySession::Decrypt(
     DRM_DWORD rgdwMappings[2];
 
     if ( (f_pcbOpaqueClearContent == NULL || f_ppbOpaqueClearContent == NULL)
-        || m_eKeyState != KEY_READY
-        || (f_pbIV == NULL || f_cbIV != sizeof(DRM_UINT64)) )
+        || (f_pbIV == NULL) )
     {
         fprintf(stderr, "Error: Decrypt - Invalid argument\n");
         return CDMi_S_FALSE;


### PR DESCRIPTION
The  m_eKeyState is not being updated in the MediaSessionExt.cpp.
The Netflix is passing IV size as 24 which is the size of OcdmAesCounterContext.